### PR TITLE
Reset vBatGain calibration

### DIFF
--- a/library.json
+++ b/library.json
@@ -7,7 +7,7 @@
        "url":"https://github.com/Infineon/high-side-switch",
        "branch":"master"
     },
-    "version":"0.1.2",
+    "version":"0.1.3",
     "license":"MIT",
     "frameworks":"arduino",
     "platforms":[  

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=High-Side-Switch
-version=0.1.2
+version=0.1.3
 author=Infineon Technologies
 maintainer=Infineon Technologies <www.infineon.com>
 sentence=C++ library for the PROFET+2 12V

--- a/src/corelib/hss-board.hpp
+++ b/src/corelib/hss-board.hpp
@@ -69,7 +69,7 @@ class HssBoard : Hss
     AnalogDigitalConverter *pushButtonAnalog;
     AnalogDigitalConverter *vBat;
 
-    const float vBatGain = 1.045;
+    const float vBatGain = 1.0;
     const float vBatOffset = 0.0;
 };
 


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Set the vBatGain to 1.0 so it is uncalibrated but therefore directly usable in most cases